### PR TITLE
fix(predictors): ensure all dictionary keys are Python strings, not n…

### DIFF
--- a/mlexplainer/core/base_predictor.py
+++ b/mlexplainer/core/base_predictor.py
@@ -263,8 +263,9 @@ class BaseMLPredictor(ABC):
             )
 
         # Store values before processing - ALL input columns (convert to regular dict with Python native types)
+        # Ensure keys are Python strings (not numpy.str_)
         values_before = {
-            col: observation[col].iloc[0].item()
+            str(col): observation[col].iloc[0].item()
             if hasattr(observation[col].iloc[0], 'item')
             else observation[col].iloc[0]
             for col in observation.columns
@@ -297,8 +298,9 @@ class BaseMLPredictor(ABC):
 
         # Store values after processing - ONLY model features (convert to regular dict with Python native types)
         # This filters out any intermediate columns created during preprocessing
+        # Ensure keys are Python strings (not numpy.str_)
         values_after = {
-            col: observation_processed[col].iloc[0].item()
+            str(col): observation_processed[col].iloc[0].item()
             if hasattr(observation_processed[col].iloc[0], 'item')
             else observation_processed[col].iloc[0]
             for col in self.features


### PR DESCRIPTION
…umpy.str_

Convert all dictionary keys in values_before_processing and values_after_processing to Python native strings to ensure consistent types across the entire output.

Changes:
- BaseMLPredictor._prepare_observation(): Wrap column names with str() when building dicts
- Applies to both values_before and values_after dictionaries

Before:
- Keys could be numpy.str_ types from pandas DataFrame columns
- Type: numpy.str_

After:
- All keys are guaranteed to be Python native strings
- Type: builtins.str

This ensures:
- Consistent JSON serialization without numpy types
- Cleaner type handling in downstream code
- No surprises when iterating over dictionary keys
- Better compatibility with JSON APIs and databases

Example:
```python
result = predictor.predict_with_contributions(observation)

# All these keys are now builtins.str, not numpy.str_
result['contributions']           # {'age': -2.8885, 'income': -2.1689}
result['values_before_processing']  # {'age': 35, 'income': 50000}
result['values_after_processing']   # {'age': 35, 'income': 50000}
```

All 204 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)